### PR TITLE
Patch Optimized direct solver + ap solver bug prior to proper fix.

### DIFF
--- a/src/ap_solver/solver.rs
+++ b/src/ap_solver/solver.rs
@@ -424,6 +424,18 @@ impl<
             direct_solve.threads,
         );
 
+        // NOTE (rb): until opt solvers handle_frustrum solves...
+        input_domain.set_aabb(direct_solve.output_aabb);
+        input_domain.par_from_superset(&output_domain, self.chunk_size);
+        std::mem::swap(&mut input_domain, &mut output_domain);
+
+        debug_assert_eq!(
+            direct_solve.output_aabb,
+            *output_domain.aabb(),
+            "ERROR: n_id: {}, Unexpected solve output",
+            node_id
+        );
+
         // copy output to output
         output.par_set_subdomain(&output_domain, self.chunk_size);
     }
@@ -461,6 +473,11 @@ impl<
             global_time,
             direct_solve.threads,
         );
+
+        // NOTE (rb): until opt solvers handle_frustrum solves...
+        input_domain.set_aabb(direct_solve.output_aabb);
+        input_domain.par_from_superset(output_domain, self.chunk_size);
+        std::mem::swap(input_domain, output_domain);
 
         debug_assert_eq!(
             direct_solve.output_aabb,


### PR DESCRIPTION
Optimized direct solvers don't do a frustum solve, they just solve the whole box. So the output domain was the wrong size and getting copied over.

Clearly I need to fix that, but this keeps correctness in the meantime.